### PR TITLE
Add Energy Meter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,10 @@
     "cSpell.words": [
         "esphome",
         "gpio",
+        "homeassistant",
         "hotspot",
         "hspi",
+        "Jameco",
         "ledc",
         "mosi",
         "Porembski",

--- a/src/power-meter.yaml
+++ b/src/power-meter.yaml
@@ -1,0 +1,222 @@
+# Using https://www.circuitstate.com/pinouts/doit-esp32-devkit-v1-wifi-development-board-pinout-diagram-and-reference
+esphome:
+  name: energy-meter
+  friendly_name: "CircuitSetup Energy Meter"
+  name_add_mac_suffix: true
+  project:
+    name: daedalus-labs.energy-meter
+    version: "0.1.0"
+
+esp32:
+  board: esp-wrover-kit
+  framework:
+    type: esp-idf
+
+# Configuration variables
+substitutions:
+  display_name: Energy Meter
+  update_time: 60s
+  wifi_update_time: 60s
+
+  # Change current_cal to the corresponding CT's that you're using
+  # If different CTs per current channel, remove or change "${current_cal}" from
+  # "gain_ct" below and replace with the CT calibration number respectively
+  # Current Transformers:
+  #  20A/25mA SCT-006: 11143
+  #  30A/1V SCT-013-030: 8650
+  #  50A/1V SCT-013-050: 15420
+  #  50A/16.6mA SCT-010: 41334
+  #  80A/26.6mA SCT-010: 41660
+  #  100A/50ma SCT-013-000: 27518
+  #  120A/40mA: SCT-016: 41787
+  #  200A/100mA SCT-024: 27518
+  #  200A/50mA SCT-024: 55036
+  current_cal: "41787"
+
+  # This only needs to be changed if you're using something other than the
+  # Jameco 9VAC Transformer:
+  voltage_cal: "7305"
+
+# Enable logging
+logger:
+  level: DEBUG
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: !secret api_key
+
+safe_mode:
+
+ota:
+  platform: esphome
+  password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  fast_connect: true
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "${display_name} AP"
+    password: !secret fallback_ap_password
+
+captive_portal:
+
+spi:
+  - id: vspi
+    clk_pin: GPIO18
+    miso_pin: GPIO19
+    mosi_pin: GPIO23
+    interface: spi3
+
+sensor:
+  # Uptime sensor
+  - platform: uptime
+    name: Uptime
+    id: uptime
+
+  # Wifi Signal
+  - platform: wifi_signal
+    name: ${display_name} WiFi
+    update_interval: ${wifi_update_time}
+
+  #IC1
+  - platform: atm90e32
+    cs_pin: 5
+    phase_a:
+      voltage:
+        name: ${display_name} Volts A
+        id: ic1Volts
+        accuracy_decimals: 1
+      current:
+        name: ${display_name} CT1 Amps
+        id: ct1Amps
+      # The max value for current that the meter can output is 65.535. If you expect to measure current over 65A,
+      # divide the gain_ct by 2 (120A CT) or 4 (200A CT) and multiply the current and power values by 2 or 4 by uncommenting the filter below
+      # filters:
+      #   - multiply: 2
+      power:
+        name: ${display_name} CT1 Watts
+        id: ct1Watts
+      # filters:
+      #   - multiply: 2
+      gain_voltage: ${voltage_cal}
+      gain_ct: ${current_cal}
+    phase_b:
+      current:
+        name: ${display_name} CT2 Amps
+        id: ct2Amps
+      power:
+        name: ${display_name} CT2 Watts
+        id: ct2Watts
+      gain_voltage: ${voltage_cal}
+      gain_ct: ${current_cal}
+    phase_c:
+      current:
+        name: ${display_name} CT3 Amps
+        id: ct3Amps
+      power:
+        name: ${display_name} CT3 Watts
+        id: ct3Watts
+      gain_voltage: ${voltage_cal}
+      gain_ct: ${current_cal}
+    frequency:
+      name: ${display_name} Frequency A
+    line_frequency: 60Hz
+    gain_pga: 1X
+    update_interval: ${update_time}
+
+  #IC2
+  - platform: atm90e32
+    cs_pin: 4
+    phase_a:
+      #this voltage is only needed if monitoring 2 voltages
+      voltage:
+        name: ${display_name} Volts B
+        id: ic2Volts
+        accuracy_decimals: 1
+      current:
+        name: ${display_name} CT4 Amps
+        id: ct4Amps
+      power:
+        name: ${display_name} CT4 Watts
+        id: ct4Watts
+      gain_voltage: ${voltage_cal}
+      gain_ct: ${current_cal}
+    phase_b:
+      current:
+        name: ${display_name} CT5 Amps
+        id: ct5Amps
+      power:
+        name: ${display_name} CT5 Watts
+        id: ct5Watts
+      gain_voltage: ${voltage_cal}
+      gain_ct: ${current_cal}
+    phase_c:
+      current:
+        name: ${display_name} CT6 Amps
+        id: ct6Amps
+      power:
+        name: ${display_name} CT6 Watts
+        id: ct6Watts
+      gain_voltage: ${voltage_cal}
+      gain_ct: ${current_cal}
+    frequency:
+      name: ${display_name} Frequency B
+    line_frequency: 60Hz
+    gain_pga: 1X
+    update_interval: ${update_time}
+
+  #Total Amps
+  - platform: template
+    name: ${display_name} Total Amps
+    id: totalAmps
+    lambda: return id(ct1Amps).state + id(ct2Amps).state + id(ct3Amps).state + id(ct4Amps).state + id(ct5Amps).state + id(ct6Amps).state ;
+    accuracy_decimals: 2
+    unit_of_measurement: A
+    device_class: current
+    update_interval: ${update_time}
+
+  #Total Watts
+  - platform: template
+    name: ${display_name} Total Watts
+    id: totalWatts
+    lambda: return id(ct1Watts).state + id(ct2Watts).state + id(ct3Watts).state + id(ct4Watts).state + id(ct5Watts).state + id(ct6Watts).state ;
+    accuracy_decimals: 1
+    unit_of_measurement: W
+    device_class: power
+    update_interval: ${update_time}
+
+  #kWh
+  - platform: total_daily_energy
+    name: ${display_name} Total kWh
+    power_id: totalWatts
+    filters:
+      - multiply: 0.001
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing
+
+output:
+  # Activity LED
+  - platform: gpio
+    pin:
+      number: 2
+      mode: output
+    id: activity_led
+
+switch:
+  - platform: restart
+    name: ${display_name} Restart
+    on_turn_on: 
+      then:
+        - output.turn_on: activity_led
+    on_turn_off: 
+      then:
+        - output.turn_off: activity_led
+
+time:
+  - platform: homeassistant
+    id: homeassistant_time

--- a/src/power-meter.yaml
+++ b/src/power-meter.yaml
@@ -15,7 +15,7 @@ esp32:
 # Configuration variables
 substitutions:
   display_name: Energy Meter
-  update_time: 60s
+  sensor_update_time: 30s
   wifi_update_time: 60s
 
   # Change current_cal to the corresponding CT's that you're using
@@ -126,7 +126,7 @@ sensor:
       name: ${display_name} Frequency A
     line_frequency: 60Hz
     gain_pga: 1X
-    update_interval: ${update_time}
+    update_interval: ${sensor_update_time}
 
   #IC2
   - platform: atm90e32
@@ -167,7 +167,7 @@ sensor:
       name: ${display_name} Frequency B
     line_frequency: 60Hz
     gain_pga: 1X
-    update_interval: ${update_time}
+    update_interval: ${sensor_update_time}
 
   #Total Amps
   - platform: template
@@ -177,7 +177,7 @@ sensor:
     accuracy_decimals: 2
     unit_of_measurement: A
     device_class: current
-    update_interval: ${update_time}
+    update_interval: ${sensor_update_time}
 
   #Total Watts
   - platform: template
@@ -187,7 +187,7 @@ sensor:
     accuracy_decimals: 1
     unit_of_measurement: W
     device_class: power
-    update_interval: ${update_time}
+    update_interval: ${sensor_update_time}
 
   #kWh
   - platform: total_daily_energy

--- a/src/power-meter.yaml
+++ b/src/power-meter.yaml
@@ -75,7 +75,7 @@ sensor:
   # Uptime sensor
   - platform: uptime
     name: Uptime
-    id: uptime
+    id: uptime_sensor
 
   # Wifi Signal
   - platform: wifi_signal

--- a/src/siren.yaml
+++ b/src/siren.yaml
@@ -60,3 +60,7 @@ switch:
     on_turn_off: 
       then:
         - output.turn_off: activity_led
+
+time:
+  - platform: homeassistant
+    id: homeassistant_time

--- a/src/smoker-controller.yaml
+++ b/src/smoker-controller.yaml
@@ -88,3 +88,7 @@ fan:
     on_turn_off: 
       then:
         - output.turn_off: activity_led
+
+time:
+  - platform: homeassistant
+    id: homeassistant_time

--- a/src/smoker-controller.yaml
+++ b/src/smoker-controller.yaml
@@ -54,16 +54,18 @@ sensor:
     cs_pin: GPIO5
     spi_id: vspi
     update_interval: 60s
+
   - platform: max6675
     id: food_temp
     name: "Food Temperature"
     cs_pin: GPIO15
     spi_id: hspi
     update_interval: 60s
+
   # Uptime sensor
   - platform: uptime
     name: Uptime
-    id: uptime
+    id: uptime_sensor
 
 output:
   # Activity LED

--- a/src/water-meter.yaml
+++ b/src/water-meter.yaml
@@ -135,3 +135,7 @@ sensor:
 #         - water_pulse.set_total_pulses:
 #             id: water_pulse
 #             value: !lambda 'return new_pulse_total;'
+
+time:
+  - platform: homeassistant
+    id: homeassistant_time


### PR DESCRIPTION
This commit adds a prelminary version of an Energy Meter based around the
Circuit Setup Expandable 6-Channel ESP32 Energy Meter. Based on templates
available [here](https://github.com/CircuitSetup/Expandable-6-Channel-ESP32-Energy-Meter/tree/master).

This commit also adds the `time` component for other ESPHome objects in testing.